### PR TITLE
Print error to stderr in core.go

### DIFF
--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -50,9 +50,10 @@ func RunCLI() {
 	var err error
 	cmd := flag.Arg(0)
 	if !plugins.CmdAvailable(cmd) {
-		fmt.Println("Inavlid cmd", cmd)
+    		fmt.Fprintln(os.Stderr, "Invalid cmd", cmd)
 		return
 	}
+	
 	plugin := plugins.GetForCmd(cmd)
 	if strings.HasPrefix(cmd, ".") {
 		plugin.Unprocess = true


### PR DESCRIPTION
Print error to stderr
Fix Typo

With the error being printed to stdout, it is conceiled by further processing the output, detrimental for trusting the validity of any output.
```sh
$ deen .h < /tmp/file1 | deen sha256
3a5c6d79a2cb27f87f4e6edf2fb3cb311482d5f7f44eae874055dc1109ce1488
$ deen .h < /tmp/file2 | deen sha256
3a5c6d79a2cb27f87f4e6edf2fb3cb311482d5f7f44eae874055dc1109ce1488
$ deen .h < /tmp/file1
Inavlid cmd .h
```